### PR TITLE
added support for telegraf and influxdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Talking about dependency injection, `xstats` comes with a [xhandler.Handler](htt
 - [DogStatsD](http://docs.datadoghq.com/guides/dogstatsd/#datagram-format)
 - [expvar](https://golang.org/pkg/expvar/)
 - [prometheus](https://github.com/prometheus/client_golang)
+- [telegraf](https://influxdata.com/blog/getting-started-with-sending-statsd-metrics-to-telegraf-influxdb)
 
 ## Install
 

--- a/telegraf/telegraf.go
+++ b/telegraf/telegraf.go
@@ -1,0 +1,92 @@
+// Package telegrafstatsd implement telegraf extended StatsD protocol for github.com/rs/xstats
+package telegraf
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/rs/xstats"
+)
+
+// Inspired by https://github.com/streadway/handy statsd package
+
+type sender chan string
+
+// MaxPacketLen is the number of bytes filled before a packet is flushed before
+// the reporting interval.
+const maxPacketLen = 2 ^ 15
+
+var tick = time.Tick
+
+// New creates a telegraf statsd sender that emit observations in the statsd
+// protocol to the passed writer. Observations are buffered for the report
+// interval or until the buffer exceeds a max packet size, whichever comes
+// first.
+func New(w io.Writer, reportInterval time.Duration) xstats.Sender {
+	s := make(chan string)
+	go fwd(w, reportInterval, s)
+	return sender(s)
+}
+
+// Gauge implements xstats.Sender interface
+func (s sender) Gauge(stat string, value float64, tags ...string) {
+	s <- fmt.Sprintf("%s,%s:%f|g\n", stat, t(tags), value)
+}
+
+// Count implements xstats.Sender interface
+func (s sender) Count(stat string, count float64, tags ...string) {
+	s <- fmt.Sprintf("%s,%s:%f|c\n", stat, t(tags), count)
+}
+
+// Histogram implements xstats.Sender interface
+func (s sender) Histogram(stat string, value float64, tags ...string) {
+	s <- fmt.Sprintf("%s,%s:%f|h\n", stat, t(tags), value)
+}
+
+// Timing implements xstats.Sender interface
+func (s sender) Timing(stat string, duration time.Duration, tags ...string) {
+	s <- fmt.Sprintf("%s,%s:%f|ms\n", stat, t(tags), duration.Seconds())
+}
+
+// Generate a telegraf tag suffix
+func t(tags []string) string {
+	for i, v := range tags {
+		tags[i] = strings.Replace(v, ":", "=", 1)
+	}
+	t := ""
+	if len(tags) > 0 {
+		t = "" + strings.Join(tags, ",")
+	}
+	return t
+}
+
+func fwd(w io.Writer, reportInterval time.Duration, c <-chan string) {
+	buf := &bytes.Buffer{}
+	tick := tick(reportInterval)
+	for {
+		select {
+		case s := <-c:
+			buf.Write([]byte(s))
+			if buf.Len() > maxPacketLen {
+				flush(w, buf)
+			}
+
+		case <-tick:
+			flush(w, buf)
+		}
+	}
+}
+
+func flush(w io.Writer, buf *bytes.Buffer) {
+	if buf.Len() <= 0 {
+		return
+	}
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		log.Printf("error: could not write to statsd: %v", err)
+	}
+	buf.Reset()
+}

--- a/telegraf/telegraf_test.go
+++ b/telegraf/telegraf_test.go
@@ -1,0 +1,103 @@
+package telegraf
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var tickC = make(chan time.Time)
+var fakeTick = func(time.Duration) <-chan time.Time { return tickC }
+
+func wait(buf *bytes.Buffer) {
+	runtime.Gosched()
+	tickC <- time.Now()
+	runtime.Gosched()
+	for i := 0; i < 10 && buf.Len() == 0; i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestCounter(t *testing.T) {
+	tick = fakeTick
+	defer func() { tick = time.Tick }()
+
+	buf := &bytes.Buffer{}
+	c := New(buf, time.Second)
+
+	c.Count("metric1", 1, "tag1")
+	c.Count("metric2", 2, "tag1", "tag2")
+	wait(buf)
+
+	assert.Equal(t, "metric1,tag1:1.000000|c\nmetric2,tag1,tag2:2.000000|c\n", buf.String())
+}
+
+func TestGauge(t *testing.T) {
+	tick = fakeTick
+	defer func() { tick = time.Tick }()
+
+	buf := &bytes.Buffer{}
+	c := New(buf, time.Second)
+
+	c.Gauge("metric1", 1, "tag1")
+	c.Gauge("metric2", -2.0, "tag1", "tag2")
+	wait(buf)
+
+	assert.Equal(t, "metric1,tag1:1.000000|g\nmetric2,tag1,tag2:-2.000000|g\n", buf.String())
+}
+
+func TestHistogram(t *testing.T) {
+	tick = fakeTick
+	defer func() { tick = time.Tick }()
+
+	buf := &bytes.Buffer{}
+	c := New(buf, time.Second)
+
+	c.Histogram("metric1", 1, "tag1")
+	c.Histogram("metric2", 2, "tag1", "tag2")
+	wait(buf)
+
+	assert.Equal(t, "metric1,tag1:1.000000|h\nmetric2,tag1,tag2:2.000000|h\n", buf.String())
+}
+
+func TestTiming(t *testing.T) {
+	tick = fakeTick
+	defer func() { tick = time.Tick }()
+
+	buf := &bytes.Buffer{}
+	c := New(buf, time.Second)
+
+	c.Timing("metric1", time.Second, "tag1")
+	c.Timing("metric2", 2*time.Second, "tag1", "tag2")
+	wait(buf)
+
+	assert.Equal(t, "metric1,tag1:1.000000|ms\nmetric2,tag1,tag2:2.000000|ms\n", buf.String())
+}
+
+type errWriter struct{}
+
+func (w errWriter) Write(p []byte) (n int, err error) {
+	return 0, errors.New("i/o error")
+}
+
+func TestInvalidBuffer(t *testing.T) {
+	tick = fakeTick
+	defer func() { tick = time.Tick }()
+
+	buf := &bytes.Buffer{}
+	log.SetOutput(buf)
+	defer func() { log.SetOutput(os.Stderr) }()
+
+	c := New(&errWriter{}, time.Second)
+
+	c.Count("metric", 1)
+	wait(buf)
+
+	assert.Contains(t, buf.String(), "error: could not write to statsd: i/o error")
+}


### PR DESCRIPTION
I have added support for the telegraf statsd format.

See: https://influxdata.com/blog/getting-started-with-sending-statsd-metrics-to-telegraf-influxdb/