### PR TITLE
dogstatsd.Timing() incorrectly sending seconds as ms

### DIFF
--- a/dogstatsd/dogstatsd.go
+++ b/dogstatsd/dogstatsd.go
@@ -49,7 +49,7 @@ func (s sender) Histogram(stat string, value float64, tags ...string) {
 
 // Timing implements xstats.Sender interface
 func (s sender) Timing(stat string, duration time.Duration, tags ...string) {
-	s <- fmt.Sprintf("%s:%f|ms%s\n", stat, duration.Seconds(), t(tags))
+	s <- fmt.Sprintf("%s:%f|ms%s\n", stat, duration.Seconds()*1000, t(tags))
 }
 
 // Generate a DogStatsD tag suffix

--- a/dogstatsd/dogstatsd_test.go
+++ b/dogstatsd/dogstatsd_test.go
@@ -77,7 +77,7 @@ func TestTiming(t *testing.T) {
 	c.Timing("metric2", 2*time.Second, "tag1", "tag2")
 	wait(buf)
 
-	assert.Equal(t, "metric1:1.000000|ms|#tag1\nmetric2:2.000000|ms|#tag1,tag2\n", buf.String())
+	assert.Equal(t, "metric1:1000.000000|ms|#tag1\nmetric2:2000.000000|ms|#tag1,tag2\n", buf.String())
 }
 
 type errWriter struct{}


### PR DESCRIPTION
That's how it's done in the [official Datadog client](https://github.com/DataDog/datadog-go/blob/b91ff63c8b9716c823d4c387aba5038a71931ddb/statsd/statsd.go#L284-L286).