### PR TITLE
statsd.Timing() incorrectly sending seconds as ms

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -48,7 +48,7 @@ func (s sender) Histogram(stat string, value float64, tags ...string) {
 
 // Timing implements xstats.Sender interface
 func (s sender) Timing(stat string, duration time.Duration, tags ...string) {
-	s <- fmt.Sprintf("%s:%f|ms\n", stat, duration.Seconds())
+	s <- fmt.Sprintf("%s:%f|ms\n", stat, duration.Seconds()*1000)
 }
 
 func fwd(w io.Writer, reportInterval time.Duration, c <-chan string) {

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -77,7 +77,7 @@ func TestTiming(t *testing.T) {
 	c.Timing("metric2", 2*time.Second, "tag1", "tag2")
 	wait(buf)
 
-	assert.Equal(t, "metric1:1.000000|ms\nmetric2:2.000000|ms\n", buf.String())
+	assert.Equal(t, "metric1:1000.000000|ms\nmetric2:2000.000000|ms\n", buf.String())
 }
 
 type errWriter struct{}


### PR DESCRIPTION
That's how it's done in the [official Statsd client](https://github.com/quipo/statsd/blob/494c2067718d0c58116be15337f466e393273617/client.go#L115-L119).