### PR TITLE
xstats: switch the tags to map[string]string

### DIFF
--- a/handler_example_test.go
+++ b/handler_example_test.go
@@ -18,7 +18,7 @@ func ExampleNewHandler() {
 
 	// Install the metric handler with dogstatsd backend client and some env tags
 	flushInterval := 5 * time.Second
-	tags := []string{"role:my-service"}
+	tags := map[string]string{"role": "my-service"}
 	statsdWriter, err := net.Dial("udp", "127.0.0.1:8126")
 	if err != nil {
 		log.Fatal(err)

--- a/handler_pre17_test.go
+++ b/handler_pre17_test.go
@@ -17,9 +17,9 @@ func TestHandler(t *testing.T) {
 		xs, ok := FromContext(ctx).(*xstats)
 		assert.True(t, ok)
 		assert.Equal(t, s, xs.s)
-		assert.Equal(t, []string{"envtag"}, xs.tags)
+		assert.Equal(t, map[string]string{"env": "prod"}, xs.tags)
 	})
-	h := NewHandler(s, []string{"envtag"})(n)
+	h := NewHandler(s, map[string]string{"env": "prod"})(n)
 	h.ServeHTTPC(context.Background(), nil, nil)
 }
 
@@ -29,9 +29,9 @@ func TestHandlerPrefix(t *testing.T) {
 		xs, ok := FromContext(ctx).(*xstats)
 		assert.True(t, ok)
 		assert.Equal(t, s, xs.s)
-		assert.Equal(t, []string{"envtag"}, xs.tags)
+		assert.Equal(t, map[string]string{"env": "prod"}, xs.tags)
 		assert.Equal(t, "prefix.", xs.prefix)
 	})
-	h := NewHandlerPrefix(s, []string{"envtag"}, "prefix.")(n)
+	h := NewHandlerPrefix(s, map[string]string{"env": "prod"}, "prefix.")(n)
 	h.ServeHTTPC(context.Background(), nil, nil)
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -13,11 +13,12 @@ func TestHandler(t *testing.T) {
 	s := &fakeSender{}
 	n := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		xs, ok := FromRequest(r).(*xstats)
-		assert.True(t, ok)
-		assert.Equal(t, s, xs.s)
-		assert.Equal(t, []string{"envtag"}, xs.tags)
+		if assert.True(t, ok) {
+			assert.Equal(t, s, xs.s)
+			assert.Equal(t, map[string]string{"env": "prod"}, xs.tags)
+		}
 	})
-	h := NewHandler(s, []string{"envtag"})(n)
+	h := NewHandler(s, map[string]string{"env": "prod"})(n)
 	h.ServeHTTP(nil, &http.Request{})
 }
 
@@ -25,11 +26,12 @@ func TestHandlerPrefix(t *testing.T) {
 	s := &fakeSender{}
 	n := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		xs, ok := FromRequest(r).(*xstats)
-		assert.True(t, ok)
-		assert.Equal(t, s, xs.s)
-		assert.Equal(t, []string{"envtag"}, xs.tags)
-		assert.Equal(t, "prefix.", xs.prefix)
+		if assert.True(t, ok) {
+			assert.Equal(t, s, xs.s)
+			assert.Equal(t, map[string]string{"env": "prod"}, xs.tags)
+			assert.Equal(t, "prefix.", xs.prefix)
+		}
 	})
-	h := NewHandlerPrefix(s, []string{"envtag"}, "prefix.")(n)
+	h := NewHandlerPrefix(s, map[string]string{"env": "prod"}, "prefix.")(n)
 	h.ServeHTTP(nil, &http.Request{})
 }

--- a/nop.go
+++ b/nop.go
@@ -11,8 +11,12 @@ var nop = &nopS{}
 func (rc *nopS) AddTags(tags ...string) {
 }
 
+// AddTag implements XStats interface
+func (rc *nopS) AddTag(key, value string) {
+}
+
 // GetTags implements XStats interface
-func (rc *nopS) GetTags() []string {
+func (rc *nopS) GetTags() map[string]string {
 	return nil
 }
 

--- a/nop_test.go
+++ b/nop_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestNop(t *testing.T) {
-	nop.AddTags("tag")
+	nop.AddTags("tag:value")
 	nop.Gauge("metric", 1)
 	nop.Count("metric", 1)
 	nop.Histogram("metric", 1)

--- a/xstats_test.go
+++ b/xstats_test.go
@@ -63,55 +63,61 @@ func TestNewPrefix(t *testing.T) {
 
 func TestCopy(t *testing.T) {
 	xs := NewPrefix(&fakeSender{}, "prefix.").(*xstats)
-	xs.AddTags("foo")
+	xs.AddTags("k1:v1")
 	xs2 := Copy(xs).(*xstats)
 	assert.Equal(t, xs.s, xs2.s)
 	assert.Equal(t, xs.tags, xs2.tags)
 	assert.Equal(t, xs.prefix, xs2.prefix)
-	xs2.AddTags("bar", "baz")
-	assert.Equal(t, []string{"foo"}, xs.tags)
-	assert.Equal(t, []string{"foo", "bar", "baz"}, xs2.tags)
+	xs2.AddTags("k2:v2", "k3:v3")
+	assert.Equal(t, map[string]string{"k1": "v1"}, xs.tags)
+	assert.Equal(t, map[string]string{"k1": "v1", "k2": "v2", "k3": "v3"}, xs2.tags)
 
 	assert.Equal(t, nop, Copy(nop))
 	assert.Equal(t, nop, Copy(nil))
 }
 
 func TestAddTag(t *testing.T) {
-	xs := &xstats{s: &fakeSender{}}
-	xs.AddTags("foo")
-	assert.Equal(t, []string{"foo"}, xs.tags)
+	xs := &xstats{s: &fakeSender{}, tags: make(map[string]string)}
+	xs.AddTag("k1", "v1")
+	assert.Equal(t, map[string]string{"k1": "v1"}, xs.tags)
+}
+
+func TestAddTags(t *testing.T) {
+	xs := &xstats{s: &fakeSender{}, tags: make(map[string]string)}
+	xs.AddTags("k1:v1")
+	assert.Equal(t, map[string]string{"k1": "v1"}, xs.tags)
 }
 
 func TestGauge(t *testing.T) {
 	s := &fakeSender{}
-	xs := &xstats{s: s, prefix: "p."}
-	xs.AddTags("foo")
-	xs.Gauge("bar", 1, "baz")
-	assert.Equal(t, cmd{"Gauge", "p.bar", 1, []string{"baz", "foo"}}, s.last)
+	xs := &xstats{s: s, prefix: "p.", tags: make(map[string]string)}
+	xs.AddTags("k1:v1")
+	xs.Gauge("bar", 1, "k2:v2")
+	assert.Equal(t, cmd{"Gauge", "p.bar", 1, []string{"k1:v1", "k2:v2"}}, s.last)
 }
 
 func TestCount(t *testing.T) {
 	s := &fakeSender{}
-	xs := &xstats{s: s, prefix: "p."}
-	xs.AddTags("foo")
-	xs.Count("bar", 1, "baz")
-	assert.Equal(t, cmd{"Count", "p.bar", 1, []string{"baz", "foo"}}, s.last)
+	xs := &xstats{s: s, prefix: "p.", tags: make(map[string]string)}
+	xs.AddTags("k1:v1")
+	xs.Count("bar", 1, "k2:v2")
+	assert.Equal(t, cmd{"Count", "p.bar", 1, []string{"k1:v1", "k2:v2"}}, s.last)
 }
 
 func TestHistogram(t *testing.T) {
 	s := &fakeSender{}
-	xs := &xstats{s: s, prefix: "p."}
-	xs.AddTags("foo")
-	xs.Histogram("bar", 1, "baz")
-	assert.Equal(t, cmd{"Histogram", "p.bar", 1, []string{"baz", "foo"}}, s.last)
+	xs := &xstats{s: s, prefix: "p.", tags: make(map[string]string)}
+	xs.AddTags("k1:v1")
+	xs.Histogram("bar", 1, "k2:v2")
+	assert.Equal(t, cmd{"Histogram", "p.bar", 1, []string{"k1:v1", "k2:v2"}}, s.last)
 }
 
 func TestTiming(t *testing.T) {
 	s := &fakeSender{}
-	xs := &xstats{s: s, prefix: "p."}
-	xs.AddTags("foo")
-	xs.Timing("bar", 1, "baz")
-	assert.Equal(t, cmd{"Timing", "p.bar", 1 / float64(time.Second), []string{"baz", "foo"}}, s.last)
+	xs := &xstats{s: s, prefix: "p.", tags: make(map[string]string)}
+	xs.AddTags("k1:v1")
+	xs.Timing("bar", 1, "k2:v2")
+	assert.Equal(t, cmd{"Timing", "p.bar", 1 / float64(time.Second), []string{"k1:v1", "k2:v2"}}, s.last)
 }
 
 func TestNilSender(t *testing.T) {


### PR DESCRIPTION
This change will prevent duplicates and allows us to override a tag already set.