### PR TITLE
Fix maxPacketLen definition

### DIFF
--- a/dogstatsd/dogstatsd.go
+++ b/dogstatsd/dogstatsd.go
@@ -22,7 +22,7 @@ type sender struct {
 
 // MaxPacketLen is the number of bytes filled before a packet is flushed before
 // the reporting interval.
-const maxPacketLen = 2 ^ 15
+const maxPacketLen = 1 << 15
 
 var tick = time.Tick
 

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -21,7 +21,7 @@ type sender struct {
 
 // MaxPacketLen is the number of bytes filled before a packet is flushed before
 // the reporting interval.
-const maxPacketLen = 2 ^ 15
+const maxPacketLen = 1 << 15
 
 var tick = time.Tick
 

--- a/telegraf/telegraf.go
+++ b/telegraf/telegraf.go
@@ -22,7 +22,7 @@ type sender struct {
 
 // MaxPacketLen is the number of bytes filled before a packet is flushed before
 // the reporting interval.
-const maxPacketLen = 2 ^ 15
+const maxPacketLen = 1 << 15
 
 var tick = time.Tick
 


### PR DESCRIPTION
I think `maxPacketLen` is supposed to be 32 KiB, not 13 (`2 ^ 15`) Bytes.