### PR TITLE
add support for scoping

### DIFF
--- a/xstats.go
+++ b/xstats.go
@@ -118,8 +118,11 @@ func (xs *xstats) Copy() XStater {
 
 // Scope implements Scoper interface
 func (xs *xstats) Scope(scope string, scopes ...string) XStater {
-	scs := make([]string, 0, 2+len(scopes))
-	if xs.prefix != "" {
+	var scs []string
+	if xs.prefix == "" {
+		scs = make([]string, 0, 1+len(scopes))
+	} else {
+		scs = make([]string, 0, 2+len(scopes))
 		scs = append(scs, strings.TrimRight(xs.prefix, xs.delimiter))
 	}
 	scs = append(scs, scope)

--- a/xstats_example_test.go
+++ b/xstats_example_test.go
@@ -29,3 +29,28 @@ func ExampleNew() {
 	s.Count("requests", 1, "tag")
 	s.Timing("something", 5*time.Millisecond, "tag")
 }
+
+func ExampleNewScoping() {
+	// Defines interval between flushes to statsd server
+	flushInterval := 5 * time.Second
+
+	// Connection to the statsd server
+	statsdWriter, err := net.Dial("udp", "127.0.0.1:8126")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create the stats client
+	s := xstats.NewScoping(dogstatsd.New(statsdWriter, flushInterval), ".", "my-thing")
+
+	// Global tags sent with all metrics (only with supported clients like datadog's)
+	s.AddTags("role:my-service", "dc:sv6")
+
+	// Send some observations
+	s.Count("requests", 1, "tag")
+	s.Timing("something", 5*time.Millisecond, "tag")
+
+	// Scope the client
+	ss := xstats.Scope(s, "my-sub-thing")
+	ss.Histogram("latency", 50, "tag")
+}


### PR DESCRIPTION
Hello! I did my best to follow local idiom here, but please let me know if there's a better way to do this. 

Background: We're moving from stock statsd to either datadog or on-site prometeus, and xstats is an ideal interface for this, since it supports all three backends. 

Our use-case is that we start our services with a base stats client, which we inject into various components, scoping the stats as we go so that local invocation is just for the metric names we care about, rather than a long complex scope string.

The change here is:
- introduce a `Scoper` interface and `Scope` function, similar to `Copier` and `Copy()`
- add a `delimiter` field to `xstats`
- introduce a `NewScoped` function that returns an `XStater` with a delimiter configured (different backends have different requirements for character sets, so I wanted to avoid hard-coding a period.)
- rephrase `NewPrefixed` to forward to `NewScoped`
- implement the `Scope()` method in `xstats`
- add tests
- add example

I'm super happy to make any changes necessary. A more minimal change would be to allow the prefix to be set; if we had this I could roll my own scoping on top. But I think this is a useful enough pattern to make available to others.

Thanks for considering the patch.