### PR TITLE
Closing an XStater closes the underlying Sender

### DIFF
--- a/sender_test.go
+++ b/sender_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestMultiSender(t *testing.T) {
 	fs1 := &fakeSender{}
-	fs2 := &fakeSenderCloser{err: errors.New("foo")}
-	fs3 := &fakeSenderCloser{err: errors.New("bar")}
+	fs2 := &fakeSendCloser{err: errors.New("foo")}
+	fs3 := &fakeSendCloser{err: errors.New("bar")}
 	m := MultiSender{fs1, fs2, fs3}
 
 	m.Count("foo", 1, "bar", "baz")

--- a/sender_test.go
+++ b/sender_test.go
@@ -1,6 +1,7 @@
 package xstats
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -9,18 +10,36 @@ import (
 
 func TestMultiSender(t *testing.T) {
 	fs1 := &fakeSender{}
-	fs2 := &fakeSender{}
-	m := MultiSender{fs1, fs2}
+	fs2 := &fakeSenderCloser{err: errors.New("foo")}
+	fs3 := &fakeSenderCloser{err: errors.New("bar")}
+	m := MultiSender{fs1, fs2, fs3}
+
 	m.Count("foo", 1, "bar", "baz")
-	assert.Equal(t, cmd{"Count", "foo", 1, []string{"bar", "baz"}}, fs1.last)
-	assert.Equal(t, cmd{"Count", "foo", 1, []string{"bar", "baz"}}, fs2.last)
+	countCmd := cmd{"Count", "foo", 1, []string{"bar", "baz"}}
+	assert.Equal(t, countCmd, fs1.last)
+	assert.Equal(t, countCmd, fs2.last)
+	assert.Equal(t, countCmd, fs3.last)
+
 	m.Gauge("foo", 1, "bar", "baz")
-	assert.Equal(t, cmd{"Gauge", "foo", 1, []string{"bar", "baz"}}, fs1.last)
-	assert.Equal(t, cmd{"Gauge", "foo", 1, []string{"bar", "baz"}}, fs2.last)
+	gaugeCmd := cmd{"Gauge", "foo", 1, []string{"bar", "baz"}}
+	assert.Equal(t, gaugeCmd, fs1.last)
+	assert.Equal(t, gaugeCmd, fs2.last)
+	assert.Equal(t, gaugeCmd, fs3.last)
+
 	m.Histogram("foo", 1, "bar", "baz")
-	assert.Equal(t, cmd{"Histogram", "foo", 1, []string{"bar", "baz"}}, fs1.last)
-	assert.Equal(t, cmd{"Histogram", "foo", 1, []string{"bar", "baz"}}, fs2.last)
+	histoCmd := cmd{"Histogram", "foo", 1, []string{"bar", "baz"}}
+	assert.Equal(t, histoCmd, fs1.last)
+	assert.Equal(t, histoCmd, fs2.last)
+	assert.Equal(t, histoCmd, fs3.last)
+
 	m.Timing("foo", 1*time.Second, "bar", "baz")
-	assert.Equal(t, cmd{"Timing", "foo", 1, []string{"bar", "baz"}}, fs1.last)
-	assert.Equal(t, cmd{"Timing", "foo", 1, []string{"bar", "baz"}}, fs2.last)
+	timingCmd := cmd{"Timing", "foo", 1, []string{"bar", "baz"}}
+	assert.Equal(t, timingCmd, fs1.last)
+	assert.Equal(t, timingCmd, fs2.last)
+	assert.Equal(t, timingCmd, fs3.last)
+
+	assert.Equal(t, fs2.err, CloseSender(m))
+	assert.Equal(t, timingCmd, fs1.last)
+	assert.Equal(t, cmd{name: "Close"}, fs2.last)
+	assert.Equal(t, cmd{name: "Close"}, fs3.last)
 }

--- a/xstats.go
+++ b/xstats.go
@@ -141,17 +141,14 @@ func (xs *xstats) Scope(scope string, scopes ...string) XStater {
 	return xs2
 }
 
-// Close closes the underlying Sender, if necessary, and returns the xstats to
-// the sync.Pool.
+// Close returns the xstats to the sync.Pool
 func (xs *xstats) Close() error {
-	// capture error, but return to pool either way
-	err := CloseSender(xs.s)
 	xs.s = nil
 	xs.tags = nil
 	xs.prefix = ""
 	xs.delimiter = ""
 	xstatsPool.Put(xs)
-	return err
+	return nil
 }
 
 // AddTag implements XStater interface

--- a/xstats_test.go
+++ b/xstats_test.go
@@ -1,7 +1,6 @@
 package xstats
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -160,25 +159,10 @@ func TestTiming(t *testing.T) {
 	assert.Equal(t, cmd{"Timing", "p.bar", 1 / float64(time.Second), []string{"baz", "foo"}}, s.last)
 }
 
-func TestClose(t *testing.T) {
-	s := &fakeSender{}
-	xs := &xstats{s: s}
-	assert.Nil(t, Close(xs))
-
-	err := errors.New("foo")
-	sc := &fakeSenderCloser{err: err}
-	xs.s = sc
-	assert.Equal(t, err, Close(xs))
-	assert.Equal(t, cmd{name: "Close"}, sc.last)
-
-	assert.Nil(t, Close(nop))
-}
-
 func TestNilSender(t *testing.T) {
 	xs := &xstats{}
 	xs.Gauge("foo", 1)
 	xs.Count("foo", 1)
 	xs.Histogram("foo", 1)
 	xs.Timing("foo", 1)
-	assert.Nil(t, xs.Close())
 }

--- a/xstats_test.go
+++ b/xstats_test.go
@@ -12,7 +12,7 @@ type fakeSender struct {
 	last cmd
 }
 
-type fakeSenderCloser struct {
+type fakeSendCloser struct {
 	fakeSender
 	err error
 }
@@ -40,7 +40,7 @@ func (s *fakeSender) Timing(stat string, duration time.Duration, tags ...string)
 	s.last = cmd{"Timing", stat, duration.Seconds(), tags}
 }
 
-func (s *fakeSenderCloser) Close() error {
+func (s *fakeSendCloser) Close() error {
 	s.fakeSender.last = cmd{name: "Close"}
 	return s.err
 }


### PR DESCRIPTION
Since callers will typically not keep a reference to the underlying `Sender`, I believe it should be closed when closing the `XStater`. 

Additionally, add convenience functions for closing `Sender`s and `XStater`s that implement `io.Closer`, and make `MultiSender` implement `io.Closer`.