### PR TITLE
Mock sender for xstats mocking on testing stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Talking about dependency injection, `xstats` comes with a [xhandler.Handler](htt
 - [expvar](https://golang.org/pkg/expvar/)
 - [prometheus](https://github.com/prometheus/client_golang)
 - [telegraf](https://influxdata.com/blog/getting-started-with-sending-statsd-metrics-to-telegraf-influxdb)
+- [mock](https://github.com/stretchr/testify)
 
 ## Install
 
@@ -77,6 +78,17 @@ http.Handle("/", h)
 
 if err := http.ListenAndServe(":8080", nil); err != nil {
     log.Fatal(err)
+}
+```
+
+## Testing
+```go
+func TestFunc(t *testing.T) {
+    m := mock.New()
+    s := xstats.New(m)
+    m.On("Timing", "something", 5*time.Millisecond, "tag")
+    s.Timing("something", 5*time.Millisecond, "tag")
+    s.AssertExpectations(t)
 }
 ```
 

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1,0 +1,38 @@
+// Package mock implements mock object for xstats Sender interface based on
+// github.com/stretchr/testify/mock package mock implementation
+package mock
+
+import (
+	"time"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type sender struct {
+	mock.Mock
+}
+
+// New creates an instance of type sender
+func New() *sender {
+	return new(sender)
+}
+
+// Gauge implements xstats.Sender interface
+func (s *sender) Gauge(stat string, value float64, tags ...string) {
+	s.Called(stat, value, tags)
+}
+
+// Count implements xstats.Sender interface
+func (s *sender) Count(stat string, count float64, tags ...string) {
+	s.Called(stat, count, tags)
+}
+
+// Histogram implements xstats.Sender interface
+func (s *sender) Histogram(stat string, value float64, tags ...string) {
+	s.Called(stat, value, tags)
+}
+
+// Timing implements xstats.Sender interface
+func (s *sender) Timing(stat string, value time.Duration, tags ...string) {
+	s.Called(stat, value, tags)
+}

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1,0 +1,28 @@
+package mock
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/rs/xstats"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	s := New()
+	assert.Implements(t, (*xstats.Sender)(nil), s)
+}
+
+func TestSender(t *testing.T) {
+	s := New()
+	d := time.Second
+	tags := []string{"2", "3"}
+	s.On("Timing", "1", d, tags)
+	s.Timing("1", d, tags...)
+	s.On("Count", "1", 2.0, tags)
+	s.Count("1", 2.0, tags...)
+	s.On("Gauge", "1", 2.0, tags)
+	s.Gauge("1", 2.0, tags...)
+	s.On("Histogram", "1", 2.0, tags)
+	s.Histogram("1", 2.0, tags...)
+	s.AssertExpectations(t)
+}


### PR DESCRIPTION
This sender based on testify/mock package is very useful when you write unit tests.
You just use the New() method to get full needed functionality.
It is very convenient and saves time for developers. 