### PR TITLE
Add option to opt-out of sync.Pool use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-- 1.6
 - 1.7
 - tip
 matrix:


### PR DESCRIPTION
When the http.Handler wrapped by the xstats middleware returns, the
internal state of the stater is cleared and the instance is returned
to the pool. However, there are quite a few cases in which a reference
to the stater escapes the context of the handler and ends up in a
background task.

When passing instances between goroutines we've established the habit
of making a copy to pass along to avoid this issue. However, when
interacting with third party code we don't always have this as an
option. For cases when it's absolutely necessary, we'd like to disable
the sync.Pool optimisation in favour of persistent stater references.

This patch adds the option in a backwards compatible way. The default
behaviour is maintained and only adding a new, explicit option to
disable the optimisation will trigger the new behaviour.