### PR TITLE
added empty sender plugin

### DIFF
--- a/emptysender/emptysender.go
+++ b/emptysender/emptysender.go
@@ -1,0 +1,31 @@
+// Package emptysender implements an empty xstats Sender interface
+// Useful for testing locally or perf benchmarks with and without instrumentation
+package emptysender
+
+import (
+	"time"
+)
+
+type sender struct {
+}
+
+// New creates an instance of type sender
+func New() *sender {
+	return new(sender)
+}
+
+// Gauge implements xstats.Sender interface
+func (s *sender) Gauge(stat string, value float64, tags ...string) {
+}
+
+// Count implements xstats.Sender interface
+func (s *sender) Count(stat string, count float64, tags ...string) {
+}
+
+// Histogram implements xstats.Sender interface
+func (s *sender) Histogram(stat string, value float64, tags ...string) {
+}
+
+// Timing implements xstats.Sender interface
+func (s *sender) Timing(stat string, value time.Duration, tags ...string) {
+}

--- a/emptysender/emptysender_test.go
+++ b/emptysender/emptysender_test.go
@@ -1,0 +1,13 @@
+package emptysender
+
+import (
+	"testing"
+
+	"github.com/rs/xstats"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	s := New()
+	assert.Implements(t, (*xstats.Sender)(nil), s)
+}


### PR DESCRIPTION
Wasn't sure if it'd be better to have a empty plugin, or to promote nop to be an exported variable (or if you don't like either of those options). 

My use case is that I have a project that uses datadog once deployed to the cloud, and locally it uses influxdb through docker-compose.  Environment variables passed into the container is what triggers which to use.  An absence of any variable defaults to no instrumentation (in this case, the empty sender).  