### PR TITLE
Export Nop for public consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ var xh xhandler.HandlerC
 // Here is your handler
 xh = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
     // Get the xstats request's instance from the context. You can safely assume it will
-    // be always there, if the handler is removed, xstats.FromContext will return a nop
+    // be always there, if the handler is removed, xstats.FromContext will return a Nop
     // instance.
     m := xstats.FromRequest(r)
 

--- a/handler.go
+++ b/handler.go
@@ -26,21 +26,21 @@ func NewContext(ctx context.Context, xs XStater) context.Context {
 }
 
 // FromContext retreives the request's xstats client from a given context if any.
-// If no xstats is embeded in the context, a nop instance is returned so you can
+// If no xstats is embeded in the context, a Nop instance is returned so you can
 // use it safely without having to test for it's presence.
 func FromContext(ctx context.Context) XStater {
 	rc, ok := ctx.Value(xstatsKey).(XStater)
 	if ok {
 		return rc
 	}
-	return nop
+	return Nop
 }
 
 // FromRequest gets the xstats client in the request's context.
 // This is a shortcut for xstats.FromContext(r.Context())
 func FromRequest(r *http.Request) XStater {
 	if r == nil {
-		return nop
+		return Nop
 	}
 	return FromContext(r.Context())
 }

--- a/handler_example_test.go
+++ b/handler_example_test.go
@@ -28,7 +28,7 @@ func ExampleNewHandler() {
 	// Here is your handler
 	h := c.HandlerH(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Get the xstats request's instance from the context. You can safely assume it will
-		// be always there, if the handler is removed, xstats.FromContext will return a nop
+		// be always there, if the handler is removed, xstats.FromContext will return a Nop
 		// instance.
 		m := xstats.FromRequest(r)
 

--- a/handler_pre17.go
+++ b/handler_pre17.go
@@ -27,14 +27,14 @@ func NewContext(ctx context.Context, xs XStater) context.Context {
 }
 
 // FromContext retreives the request's xstats client from a given context if any.
-// If no xstats is embeded in the context, a nop instance is returned so you can
+// If no xstats is embeded in the context, a Nop instance is returned so you can
 // use it safely without having to test for it's presence.
 func FromContext(ctx context.Context) XStater {
 	rc, ok := ctx.Value(xstatsKey).(XStater)
 	if ok {
 		return rc
 	}
-	return nop
+	return Nop
 }
 
 // NewHandler creates a new handler with the provided metric client.

--- a/nop.go
+++ b/nop.go
@@ -5,7 +5,7 @@ import "time"
 type nopS struct {
 }
 
-var nop = &nopS{}
+var Nop = &nopS{}
 
 // AddTags implements XStats interface
 func (rc *nopS) AddTags(tags ...string) {

--- a/nop_test.go
+++ b/nop_test.go
@@ -6,9 +6,9 @@ import (
 )
 
 func TestNop(t *testing.T) {
-	nop.AddTags("tag")
-	nop.Gauge("metric", 1)
-	nop.Count("metric", 1)
-	nop.Histogram("metric", 1)
-	nop.Timing("metric", 1*time.Second)
+	Nop.AddTags("tag")
+	Nop.Gauge("metric", 1)
+	Nop.Count("metric", 1)
+	Nop.Histogram("metric", 1)
+	Nop.Timing("metric", 1*time.Second)
 }

--- a/xstats.go
+++ b/xstats.go
@@ -97,21 +97,21 @@ func NewScoping(s Sender, delimiter string, scopes ...string) XStater {
 }
 
 // Copy makes a copy of the given XStater if it implements the Copier
-// interface. Otherwise it returns a nop stats.
+// interface. Otherwise it returns a Nop stats.
 func Copy(xs XStater) XStater {
 	if c, ok := xs.(Copier); ok {
 		return c.Copy()
 	}
-	return nop
+	return Nop
 }
 
 // Scope makes a scoped copy of the given XStater if it implements the Scoper
-// interface. Otherwise it returns a nop stats.
+// interface. Otherwise it returns a Nop stats.
 func Scope(xs XStater, scope string, scopes ...string) XStater {
 	if c, ok := xs.(Scoper); ok {
 		return c.Scope(scope, scopes...)
 	}
-	return nop
+	return Nop
 }
 
 // Close will call Close() on any xstats.XStater that implements io.Closer

--- a/xstats_test.go
+++ b/xstats_test.go
@@ -49,7 +49,7 @@ func (s *fakeSendCloser) Close() error {
 func TestContext(t *testing.T) {
 	ctx := context.Background()
 	s := FromContext(ctx)
-	assert.Equal(t, nop, s)
+	assert.Equal(t, Nop, s)
 
 	ctx = context.Background()
 	xs := &xstats{}
@@ -118,8 +118,8 @@ func TestCopy(t *testing.T) {
 	assert.Equal(t, []string{"foo"}, xs.tags)
 	assert.Equal(t, []string{"foo", "bar", "baz"}, xs2.tags)
 
-	assert.Equal(t, nop, Copy(nop))
-	assert.Equal(t, nop, Copy(nil))
+	assert.Equal(t, Nop, Copy(Nop))
+	assert.Equal(t, Nop, Copy(nil))
 }
 
 func TestScope(t *testing.T) {
@@ -142,8 +142,8 @@ func TestScope(t *testing.T) {
 	assert.Equal(t, []string{"foo", "bar", "baz"}, xs2.tags)
 	assert.Equal(t, []string{"foo", "blegga"}, xs3.tags)
 
-	assert.Equal(t, nop, Scope(nop, "prefix"))
-	assert.Equal(t, nop, Scope(nil, "prefix"))
+	assert.Equal(t, Nop, Scope(Nop, "prefix"))
+	assert.Equal(t, Nop, Scope(nil, "prefix"))
 }
 
 func TestAddTag(t *testing.T) {


### PR DESCRIPTION
Simply exports Nop so it can be consumed by users of the library.

#23 wanted to do this, but added a new empty plugin instead. Exporting Nop is better.